### PR TITLE
Enable browser-based OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 pip install -r requirements.txt
 ```
 
-2. Export your Spotify library. On first run you will be asked to authorize the application in your browser:
+2. Export your Spotify library. On first run a browser window will open so you can log into Spotify and authorize the app:
 
 ```bash
 python -m spotiport.export_spotify
@@ -22,7 +22,7 @@ python -m spotiport.export_spotify
 
 This creates a `spotify_library.json` file containing your liked songs and playlists.
 
-3. Obtain YouTube credentials by creating an OAuth client in the Google Developer Console and save the file as `client_secret.json` in the project root.
+3. Obtain YouTube credentials by creating an OAuth client in the Google Developer Console and save the file as `client_secret.json` in the project root. When importing, your default browser will open for Google sign in.
 
 4. Import the library into YouTube Music:
 

--- a/spotiport/export_spotify.py
+++ b/spotiport/export_spotify.py
@@ -10,7 +10,7 @@ SCOPE = "user-library-read playlist-read-private playlist-read-collaborative"
 
 def get_spotify_client() -> spotipy.Spotify:
     """Authenticate and return a Spotify client using OAuth."""
-    auth = SpotifyOAuth(scope=SCOPE)
+    auth = SpotifyOAuth(scope=SCOPE, open_browser=True)
     return spotipy.Spotify(auth_manager=auth)
 
 
@@ -70,6 +70,7 @@ def export_playlists(sp: spotipy.Spotify) -> List[Dict]:
 
 def export_library(output_file: str = "spotify_library.json") -> None:
     """Export liked songs and playlists to a JSON file."""
+    print("A browser window will open to authorize Spotify access.")
     sp = get_spotify_client()
     data = {
         "liked_songs": export_liked_tracks(sp),

--- a/spotiport/import_youtube.py
+++ b/spotiport/import_youtube.py
@@ -15,7 +15,9 @@ YT_SCOPE = ["https://www.googleapis.com/auth/youtube"]
 def get_youtube_client() -> any:
     """Authenticate and return a YouTube API client."""
     flow = InstalledAppFlow.from_client_secrets_file("client_secret.json", YT_SCOPE)
-    creds = flow.run_console()
+    # Open the user's browser for a graphical login and run a local server to
+    # receive the authorization code.
+    creds = flow.run_local_server(port=0)
     return build("youtube", "v3", credentials=creds)
 
 
@@ -99,6 +101,7 @@ def port_playlist(youtube, playlist: Dict, failed: List[Dict]) -> None:
 
 
 def import_library(library_file: str, failed_log: str = FAILED_LOG_FILE) -> None:
+    print("A browser window will open to authorize your Google account.")
     youtube = get_youtube_client()
     data = json.loads(Path(library_file).read_text())
     failed: List[Dict] = []


### PR DESCRIPTION
## Summary
- enable browser login for Spotify and Google OAuth
- note login steps in documentation

## Testing
- `python -m py_compile spotiport/*.py`
- `python -m spotiport.export_spotify --help` *(fails: No client ID)*
- `python -m spotiport.import_youtube --help` *(fails: missing `client_secret.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686a96ad6e10832098e680576800eb67