### PR TITLE
Enable browser-based OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@
 pip install -r requirements.txt
 ```
 
-2. Export your Spotify library. On first run you will be asked to authorize the application in your browser:
+2. Export your Spotify library. On first run a browser window will open so you can log into Spotify and authorize the app. If Spotify API credentials are not found, you will be prompted to enter them. You can obtain these by registering an application in the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard):
 
 ```bash
 python -m spotiport.export_spotify
 ```
 
 This creates a `spotify_library.json` file containing your liked songs and playlists.
+The credentials you enter will be saved in a local `.env` file for future use.
 
-3. Obtain YouTube credentials by creating an OAuth client in the Google Developer Console and save the file as `client_secret.json` in the project root.
+3. Obtain YouTube credentials by creating an OAuth client in the Google Developer Console and save the file as `client_secret.json` in the project root. When importing, your default browser will open for Google sign in.
 
 4. Import the library into YouTube Music:
 
@@ -33,3 +34,7 @@ python -m spotiport.import_youtube spotify_library.json
 The script creates new playlists prefixed with `spoti-port-` and attempts to match each track by searching YouTube and selecting the result with the closest duration.
 
 Any songs that cannot be matched are saved to `failed_tracks.json` so you can review and handle them later.
+
+## Spotify API Limits
+
+Spotify's Web API enforces rate limits. The exact numbers aren't published, but if too many requests are made in a short time the API will return HTTP `429 Too Many Requests` along with a `Retry-After` header indicating when you can try again. The export script fetches data sequentially so it generally stays well below these limits, but very large libraries may require waiting if a rate limit response is encountered.

--- a/spotiport/export_spotify.py
+++ b/spotiport/export_spotify.py
@@ -1,5 +1,33 @@
 import json
+import os
 from typing import List, Dict
+
+
+def _load_env(path: str = ".env") -> None:
+    """Load environment variables from a simple .env file if present."""
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip() and not line.strip().startswith("#") and "=" in line:
+                    key, val = line.strip().split("=", 1)
+                    os.environ.setdefault(key, val)
+
+
+def _prompt_for_credentials() -> None:
+    """Interactively ask the user for Spotify API credentials."""
+    print("Spotify API credentials are required to access your library.")
+    client_id = input("Enter your SPOTIPY_CLIENT_ID: ").strip()
+    client_secret = input("Enter your SPOTIPY_CLIENT_SECRET: ").strip()
+    redirect_uri = input(
+        "Enter SPOTIPY_REDIRECT_URI [http://localhost:8888/callback]: "
+    ).strip() or "http://localhost:8888/callback"
+    with open(".env", "a", encoding="utf-8") as f:
+        f.write(f"SPOTIPY_CLIENT_ID={client_id}\n")
+        f.write(f"SPOTIPY_CLIENT_SECRET={client_secret}\n")
+        f.write(f"SPOTIPY_REDIRECT_URI={redirect_uri}\n")
+    os.environ["SPOTIPY_CLIENT_ID"] = client_id
+    os.environ["SPOTIPY_CLIENT_SECRET"] = client_secret
+    os.environ["SPOTIPY_REDIRECT_URI"] = redirect_uri
 
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
@@ -10,7 +38,12 @@ SCOPE = "user-library-read playlist-read-private playlist-read-collaborative"
 
 def get_spotify_client() -> spotipy.Spotify:
     """Authenticate and return a Spotify client using OAuth."""
-    auth = SpotifyOAuth(scope=SCOPE)
+    _load_env()
+    client_id = os.getenv("SPOTIPY_CLIENT_ID")
+    client_secret = os.getenv("SPOTIPY_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        _prompt_for_credentials()
+    auth = SpotifyOAuth(scope=SCOPE, open_browser=True)
     return spotipy.Spotify(auth_manager=auth)
 
 
@@ -70,6 +103,7 @@ def export_playlists(sp: spotipy.Spotify) -> List[Dict]:
 
 def export_library(output_file: str = "spotify_library.json") -> None:
     """Export liked songs and playlists to a JSON file."""
+    print("A browser window will open to authorize Spotify access.")
     sp = get_spotify_client()
     data = {
         "liked_songs": export_liked_tracks(sp),

--- a/spotiport/import_youtube.py
+++ b/spotiport/import_youtube.py
@@ -14,8 +14,16 @@ YT_SCOPE = ["https://www.googleapis.com/auth/youtube"]
 
 def get_youtube_client() -> any:
     """Authenticate and return a YouTube API client."""
+    if not Path("client_secret.json").exists():
+        raise RuntimeError(
+            "client_secret.json not found. Create OAuth credentials in the "
+            "Google Developer Console and download the JSON file to this "
+            "directory."
+        )
     flow = InstalledAppFlow.from_client_secrets_file("client_secret.json", YT_SCOPE)
-    creds = flow.run_console()
+    # Open the user's browser for a graphical login and run a local server to
+    # receive the authorization code.
+    creds = flow.run_local_server(port=0)
     return build("youtube", "v3", credentials=creds)
 
 
@@ -99,6 +107,7 @@ def port_playlist(youtube, playlist: Dict, failed: List[Dict]) -> None:
 
 
 def import_library(library_file: str, failed_log: str = FAILED_LOG_FILE) -> None:
+    print("A browser window will open to authorize your Google account.")
     youtube = get_youtube_client()
     data = json.loads(Path(library_file).read_text())
     failed: List[Dict] = []


### PR DESCRIPTION
## Summary
- enable browser login for Spotify and Google OAuth
- note login steps in documentation
- check for Spotify credentials and load from `.env`
- document API rate limits and credential setup
- add interactive credential prompt and error for missing Google credentials

## Testing
- `python -m py_compile spotiport/*.py`
- `SPOTIPY_CLIENT_ID=dummy SPOTIPY_CLIENT_SECRET=dummy SPOTIPY_REDIRECT_URI=http://localhost python -m spotiport.export_spotify` *(hangs awaiting OAuth)*
- `python -m spotiport.import_youtube spotify_library.json` *(fails: missing `client_secret.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686a96ad6e10832098e680576800eb67