### PR TITLE
Fix static redirect for YouTube OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ python -m spotiport.export_spotify
 This creates a `spotify_library.json` file containing your liked songs and playlists.
 The credentials you enter will be saved in a local `.env` file for future use.
 
-3. Obtain YouTube credentials by creating an OAuth client in the Google Developer Console and save the file as `client_secret.json` in the project root. When importing, your default browser will open for Google sign in.
+3. Obtain YouTube credentials by creating an OAuth client in the Google Developer Console and save the file as `client_secret.json` in the project root. When importing, your default browser will open for Google sign in. **Register `http://localhost:8080/` as an authorized redirect URI** so the authentication flow can use a fixed callback URL.
 
 4. Import the library into YouTube Music:
 

--- a/spotiport/import_youtube.py
+++ b/spotiport/import_youtube.py
@@ -32,10 +32,14 @@ def get_youtube_client() -> any:
             "Google Developer Console and download the JSON file to this "
             "directory."
         )
-    flow = InstalledAppFlow.from_client_secrets_file("client_secret.json", YT_SCOPE)
+    # Use a fixed redirect URI so it can be whitelisted in the Google console.
+    redirect_uri = "http://localhost:8080/"
+    flow = InstalledAppFlow.from_client_secrets_file(
+        "client_secret.json", YT_SCOPE, redirect_uri=redirect_uri
+    )
     # Open the user's browser for a graphical login and run a local server to
-    # receive the authorization code.
-    creds = flow.run_local_server(port=0)
+    # receive the authorization code on the same port each time.
+    creds = flow.run_local_server(port=8080)
     return build("youtube", "v3", credentials=creds)
 
 


### PR DESCRIPTION
## Summary
- use a fixed redirect URI/port when authenticating with YouTube
- document the new redirect URI requirement

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile spotiport/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686aab993bcc83209340861cf720a42f