### PR TITLE
Improve import workflow with interactive sync selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The credentials you enter will be saved in a local `.env` file for future use.
 
 Make sure the **YouTube Data API v3** is enabled in the same Google Cloud project where you created the OAuth credentials. If it isn't enabled, the import command will fail with a 403 error indicating that the API is disabled or hasn't been used in your project.
 
-4. Import the library into YouTube Music. The command now syncs your Spotify
-   **Liked Songs** with the saved songs in YouTube Music and lets you choose
-   which playlists to port:
+4. Import the library into YouTube Music. The command now asks which parts of
+   your library you want to sync—**Liked Songs**, specific playlists, or
+   everything:
 
 ```bash
 python -m spotiport.import_youtube spotify_library.json
@@ -41,9 +41,9 @@ python -m spotiport.import_youtube spotify_library.json
 
 The script creates new playlists prefixed with `spoti-port-` and attempts to
 match each track by searching YouTube and selecting the result with the closest
-duration. After each playlist completes you're asked if you want to port another
-one. Any songs that cannot be matched are appended to `failed_tracks.json` with
-the playlist name so you can review them later.
+duration. After each item completes you're asked if you want to sync another.
+Any songs that cannot be matched are appended to `failed_tracks.json` so you can
+review them later.
 
 ## Spotify API Limits
 


### PR DESCRIPTION
## Summary
- prompt user to choose what to sync instead of always syncing liked songs
- update README to describe new behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ab9d49f288320834f27077d722126